### PR TITLE
Adjust frequency plotting function

### DIFF
--- a/aiida_skeaf/utils/plot.py
+++ b/aiida_skeaf/utils/plot.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 """Functions to plot output results."""
-import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -37,7 +36,7 @@ def complement_color(r, g, b):
     return tuple(k - u for u in (r, g, b))
 
 
-def plot_xy(
+def plot_xy(  # pylint: disable=too-many-arguments
     x: np.ndarray,
     y: np.ndarray,
     *,
@@ -45,6 +44,7 @@ def plot_xy(
     xlabel: str = None,
     ylabel: str = None,
     title: str = "Frequency vs angle",
+    invert_x: bool = False,
     ax: plt.Axes = None,
 ) -> None:
     """Plot raw data.
@@ -63,18 +63,12 @@ def plot_xy(
         _, ax = plt.subplots(1, 1)
         show_plot = True
 
-    line2D = ax.plot(x, y)
-    line_color = line2D[0].get_c()
-    line_color = mpl.colors.to_rgb(line_color)
-    # edge_color = "r"
-    edge_color = complement_color(*line_color)
-
+    if invert_x:
+        ax.xaxis.set_inverted(True)
     ax.scatter(
         x,
         y,
         marker="o",
-        facecolors="none",
-        edgecolors=edge_color,
         label=label,
     )
 
@@ -117,7 +111,7 @@ def plot_frequency(
     if multiply_cosine:
         y_array *= np.cos(x_array / 180 * np.pi)
 
-    header = frequency.attributes["header"].strip().split(",")
+    header = frequency.base.attributes.all["header"].strip().split(",")
 
     xlabel = [_ for _ in header if x in _.lower()][0]
     ylabel = [_ for _ in header if y in _.lower()][0]

--- a/aiida_skeaf/utils/plot.py
+++ b/aiida_skeaf/utils/plot.py
@@ -45,6 +45,11 @@ def plot_xy(  # pylint: disable=too-many-arguments
     ylabel: str = None,
     title: str = "Frequency vs angle",
     ax: plt.Axes = None,
+    show_plot: bool = False,
+    show_legend: bool = True,
+    x_offset: float = 0.0,
+    scale_x: float = 1.0,
+    invert_x: bool = False,
     **kwargs,
 ) -> None:
     """Plot raw data.
@@ -57,24 +62,30 @@ def plot_xy(  # pylint: disable=too-many-arguments
     :type label: str, optional
     :param ax: If provided reuse this matplotlib axes, defaults to None
     :type ax: matplotlib.pyplot.Axes, optional
+    :param show_plot: _description_, defaults to False
+    :type show_plot: bool, optional
+    :param show_legend: _description_, defaults to True
+    :type show_legend: bool, optional
+    :param x_offset: _description_, defaults to 0.0
+    :type x_offset: float, optional
+    :param scale_x: _description_, defaults to 1.0
+    :type scale_x: float, optional
     """
-    show_plot = False
+
     if ax is None:
         _, ax = plt.subplots(1, 1)
         show_plot = True
 
-    if "invert_x" in kwargs:
-        if kwargs["invert_x"]:
-            ax.xaxis.set_inverted(True)
+    if invert_x:
+        ax.xaxis.set_inverted(True)
 
-    scatter = ax.scatter(
-        x,
+    ax.scatter(
+        scale_x * x + x_offset,
         y,
-        marker="o",
         label=label,
+        **kwargs,
     )
-    if "color" in kwargs:
-        scatter.set_color(kwargs["color"])
+
     xlabel = kwargs.get("xlabel", xlabel)
     ylabel = kwargs.get("ylabel", ylabel)
     title = kwargs.get("title", title)
@@ -82,7 +93,8 @@ def plot_xy(  # pylint: disable=too-many-arguments
     ax.set_ylabel(ylabel)
     ax.set_title(title)
 
-    ax.legend()
+    if show_legend:
+        ax.legend()
 
     if show_plot:
         plt.show()
@@ -165,7 +177,6 @@ def plot_frequency_workchain(
         plot_frequency(frequency=frequency, label=band_idx, ax=ax, **kwargs)
 
     ax.set_title(f"{wkchain.process_label}<{wkchain.pk}>")
-    ax.legend()
 
     if show_plot:
         plt.show()

--- a/aiida_skeaf/utils/plot.py
+++ b/aiida_skeaf/utils/plot.py
@@ -44,8 +44,8 @@ def plot_xy(  # pylint: disable=too-many-arguments
     xlabel: str = None,
     ylabel: str = None,
     title: str = "Frequency vs angle",
-    invert_x: bool = False,
     ax: plt.Axes = None,
+    **kwargs,
 ) -> None:
     """Plot raw data.
 
@@ -63,15 +63,21 @@ def plot_xy(  # pylint: disable=too-many-arguments
         _, ax = plt.subplots(1, 1)
         show_plot = True
 
-    if invert_x:
-        ax.xaxis.set_inverted(True)
-    ax.scatter(
+    if "invert_x" in kwargs:
+        if kwargs["invert_x"]:
+            ax.xaxis.set_inverted(True)
+
+    scatter = ax.scatter(
         x,
         y,
         marker="o",
         label=label,
     )
-
+    if "color" in kwargs:
+        scatter.set_color(kwargs["color"])
+    xlabel = kwargs.get("xlabel", xlabel)
+    ylabel = kwargs.get("ylabel", ylabel)
+    title = kwargs.get("title", title)
     ax.set_xlabel(xlabel)
     ax.set_ylabel(ylabel)
     ax.set_title(title)


### PR DESCRIPTION
  * Remove the line, leave only the scatter plot
  * Allow to invert x axis when plotting dHvA frequencies
    add `invert_x: bool = False` argument to `plot_xy` function, which is called when executing `plot_frequency_workchain` or `plot_frequency_calc` functions. This is useful when comparing different rotation paths if at one of the paths the relevant angle is decreasing.
  * Small fix to avoid `AiidaDeprecationWarning`