### PR TITLE
Remove codeinfo.withmpi from SkeafCalculation to avoid exception

### DIFF
--- a/aiida_skeaf/calculations/skeaf.py
+++ b/aiida_skeaf/calculations/skeaf.py
@@ -83,7 +83,6 @@ class SkeafCalculation(CalcJob):
         codeinfo.cmdline_params = ["-rdcfg"]
         codeinfo.code_uuid = self.inputs.code.uuid
         codeinfo.stdout_name = self.metadata.options.output_filename
-        codeinfo.withmpi = self.inputs.metadata.options.withmpi
 
         # Prepare a `CalcInfo` to be returned to the engine
         calcinfo = datastructures.CalcInfo()


### PR DESCRIPTION
There was the following error when submitting SkeafCalculation:
```
*** 1 LOG MESSAGES:
+-> REPORT at 2026-03-10 16:53:35.029558+00:00
 | [8119854|SkeafCalculation|on_except]: Traceback (most recent call last):
 |   File "/home/aiida/.aiida_venvs/fermisurf/lib/python3.10/site-packages/plumpy/utils.py", line 92, in __getattr__
 |     return self[attr]
 |   File "/home/aiida/.aiida_venvs/fermisurf/lib/python3.10/site-packages/plumpy/utils.py", line 50, in __getitem__
 |     return self._dict[key]
 | KeyError: 'withmpi'
 | 
 | During handling of the above exception, another exception occurred:
 | 
 | Traceback (most recent call last):
 |   File "/home/aiida/.aiida_venvs/fermisurf/lib/python3.10/site-packages/aiida/engine/processes/calcjobs/tasks.py", line 92, in do_upload
 |     calc_info = process.presubmit(folder)
 |   File "/home/aiida/.aiida_venvs/fermisurf/lib/python3.10/site-packages/aiida/engine/processes/calcjobs/calcjob.py", line 883, in presubmit
 |     calc_info = self.prepare_for_submission(folder)
 |   File "/home/aiida/.aiida_venvs/fermisurf/lib/python3.10/site-packages/aiida_skeaf/calculations/skeaf.py", line 86, in prepare_for_submission
 |     codeinfo.withmpi = self.inputs.metadata.options.withmpi
 |   File "/home/aiida/.aiida_venvs/fermisurf/lib/python3.10/site-packages/plumpy/utils.py", line 95, in __getattr__
 |     raise AttributeError(errmsg)
 | AttributeError: 'AttributesFrozendict' object has no attribute 'withmpi'
 | 
 | The above exception was the direct cause of the following exception:
 | 
 | Traceback (most recent call last):
 |   File "/home/aiida/.aiida_venvs/fermisurf/lib/python3.10/site-packages/plumpy/processes.py", line 1334, in step
 |     next_state = await self._run_task(self._state.execute)
 |   File "/home/aiida/.aiida_venvs/fermisurf/lib/python3.10/site-packages/plumpy/processes.py", line 607, in _run_task
 |     result = await coro(*args, **kwargs)
 |   File "/home/aiida/.aiida_venvs/fermisurf/lib/python3.10/site-packages/aiida/engine/processes/calcjobs/tasks.py", line 518, in execute
 |     skip_submit = await self._launch_task(task_upload_job, self.process, transport_queue)
 |   File "/home/aiida/.aiida_venvs/fermisurf/lib/python3.10/site-packages/aiida/engine/processes/calcjobs/tasks.py", line 637, in _launch_task
 |     result = await self._task
 |   File "/usr/lib/python3.10/asyncio/tasks.py", line 304, in __wakeup
 |     future.result()
 |   File "/home/aiida/.aiida_venvs/fermisurf/lib/python3.10/site-packages/aiida/engine/utils.py", line 137, in execute_coroutine
 |     result = await coro(future)
 |   File "/home/aiida/.aiida_venvs/fermisurf/lib/python3.10/site-packages/aiida/engine/processes/calcjobs/tasks.py", line 106, in task_upload_job
 |     skip_submit = await utils.exponential_backoff_retry(
 |   File "/home/aiida/.aiida_venvs/fermisurf/lib/python3.10/site-packages/aiida/engine/utils.py", line 205, in exponential_backoff_retry
 |     result = await coro()
 |   File "/home/aiida/.aiida_venvs/fermisurf/lib/python3.10/site-packages/aiida/engine/processes/calcjobs/tasks.py", line 94, in do_upload
 |     raise PreSubmitException('exception occurred in presubmit call') from exception
 | aiida.engine.processes.calcjobs.tasks.PreSubmitException: exception occurred in presubmit call
```
