### PR TITLE
Update CI and configuration to return support for Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.9", "3.10"]
 
     services:
       postgres:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
   rev: v3.13.0
   hooks:
   - id: pyupgrade
-    args: ["--py310-plus"]
+    args: ["--py39-plus"]
 
 - repo: https://github.com/PyCQA/isort
   rev: 5.12.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Framework :: AiiDA"
 ]
 keywords = ["aiida", "plugin"]
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 dependencies = [
     "aiida-core>=1.6.4,<3",
     "aiida-wannier90-workflows>=2.1.0",
@@ -121,12 +121,12 @@ known_aiida_wannier90_workflows = ['aiida_wannier90_workflows']
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py310
+envlist = py39
 
 [testenv]
 usedevelop=True
 
-[testenv:py{310,311,312}]
+[testenv:py{39,310,311,312}]
 description = Run the test suite against a python version
 extras = testing
 commands = pytest {posargs}


### PR DESCRIPTION
This pull request updates the project's Python version support to include Python 3.9 in addition to 3.10. Asked by @edan-bainglass since AiiDAlab is still on 3.9. The changes ensure compatibility and proper testing across both versions by updating configuration files and tooling.

**Python version support and compatibility:**

* Updated the `pyproject.toml` to lower the minimum required Python version from 3.10 to 3.9 (`requires-python = ">=3.9"`).
* Modified the GitHub Actions workflow (`.github/workflows/ci.yml`) to run CI tests on both Python 3.9 and 3.10.
* Adjusted the tox configuration in `pyproject.toml` to add a Python 3.9 environment and include it in the test matrix.

**Tooling and linting configuration:**

* Changed the `pyupgrade` pre-commit hook argument from `--py310-plus` to `--py39-plus` in `.pre-commit-config.yaml`, ensuring code style checks are compatible with Python 3.9+.